### PR TITLE
Fix callerId Android when receiving a call

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Accelerate.framework
 ```
 
 #### Android
-Copy folder [jniLibs](https://github.com/ttdat89/react-native-video-quickblox/tree/master/example/TestLibQuickblox/android/app/src/main/jniLibs) in [https://github.com/ttdat89/react-native-video-quickblox/tree/master/example/TestLibQuickblox/android/app/src/main/](https://github.com/ttdat89/react-native-video-quickblox/tree/master/example/TestLibQuickblox/android/app/src/main/) to your Android project
+* Copy folder [jniLibs](https://github.com/ttdat89/react-native-video-quickblox/tree/master/example/TestLibQuickblox/android/app/src/main/jniLibs) in [https://github.com/ttdat89/react-native-video-quickblox/tree/master/example/TestLibQuickblox/android/app/src/main/](https://github.com/ttdat89/react-native-video-quickblox/tree/master/example/TestLibQuickblox/android/app/src/main/) to your Android project
+
+* Add **compile 'com.google.code.gson:gson:2.8.2'** in dependencies ```build.gradle```
 
 
 ## Usage

--- a/android/src/main/java/com/sts/RNQuickblox/QuickbloxHandler.java
+++ b/android/src/main/java/com/sts/RNQuickblox/QuickbloxHandler.java
@@ -132,7 +132,7 @@ public class QuickbloxHandler implements QBRTCClientVideoTracksCallbacks<QBRTCSe
 
                 setSession(qbrtcSession);
                 //[self.localViewManager attachLocalCameraStream:self.session];
-                quickbloxClient.receiveCallSession(session, Integer.valueOf(session.getUserInfo().get("userId")));
+                quickbloxClient.receiveCallSession(session, qbrtcSession.getCallerID());
             }
 
             @Override


### PR DESCRIPTION
There is no "userId" in **getUserInfo()**, replace by function **getCallerID()**
```java
@Override
public void onReceiveNewSession(QBRTCSession qbrtcSession) {

                if (session != null && qbrtcSession.getSessionID().equals(session.getSessionID())) {
                    session.rejectCall(new HashMap<String, String>() {{
                        put("key", "value");
                    }});
                    return;
                }

                setSession(qbrtcSession);
                //[self.localViewManager attachLocalCameraStream:self.session];

// --> Change this line
                quickbloxClient.receiveCallSession(session, qbrtcSession.getCallerID());
}
```